### PR TITLE
added business partner feature

### DIFF
--- a/UnitTest_CodeReviews_SDLC/CodeReviewExamples/Production/BusinessPartners/BusinessPartner.cs
+++ b/UnitTest_CodeReviews_SDLC/CodeReviewExamples/Production/BusinessPartners/BusinessPartner.cs
@@ -4,4 +4,20 @@ public class BusinessPartner(int partnerCode)
 {
     private VerificationStatus _status = VerificationStatus.Unverified;
     public int PartnerCode { get; private set; } = partnerCode;
+
+    public bool IsEligibleForLeaseContracts() => _status switch
+    {
+        VerificationStatus.Verified => true,
+        _ => false
+    };
+
+    public void Verify()
+    {
+        _status = VerificationStatus.Verified;
+    }
+    
+    public void Reject()
+    {
+        _status = VerificationStatus.Rejected;
+    }
 }

--- a/UnitTest_CodeReviews_SDLC/CodeReviewExamples/Production/BusinessPartners/Commands/RemoveBusinessPartnerFromArchiveCommand.cs
+++ b/UnitTest_CodeReviews_SDLC/CodeReviewExamples/Production/BusinessPartners/Commands/RemoveBusinessPartnerFromArchiveCommand.cs
@@ -1,0 +1,20 @@
+using CodeReviewExamples.Production.BusinessPartners.Services;
+
+namespace CodeReviewExamples.Production.BusinessPartners.Commands;
+
+public class RemoveBusinessPartnerFromArchiveCommand(
+    bool isTestEnvironment,
+    IMailService mailService,
+    IBusinessPartnerArchive businessPartnerArchive)
+{
+
+    public async Task Execute(int partnerCode)
+    {
+        await businessPartnerArchive.RemoveBusinessPartnerFromArchiveAsync(partnerCode);
+
+        if (!isTestEnvironment)
+        {
+            mailService.SendMail("Partner Removed", $"The partner with code {partnerCode} was removed from the archive", "someoneimportant@business.com");
+        }
+    }
+}

--- a/UnitTest_CodeReviews_SDLC/CodeReviewExamples/Production/BusinessPartners/Services/BusinessPartnerNotFoundException.cs
+++ b/UnitTest_CodeReviews_SDLC/CodeReviewExamples/Production/BusinessPartners/Services/BusinessPartnerNotFoundException.cs
@@ -1,0 +1,4 @@
+namespace CodeReviewExamples.Production.BusinessPartners.Services;
+
+public class BusinessPartnerNotFoundException(int partnerCode)
+    : Exception($"Business Partner with Code {partnerCode} was not found.");

--- a/UnitTest_CodeReviews_SDLC/CodeReviewExamples/Production/BusinessPartners/Services/BusinessPartnerRepository.cs
+++ b/UnitTest_CodeReviews_SDLC/CodeReviewExamples/Production/BusinessPartners/Services/BusinessPartnerRepository.cs
@@ -1,0 +1,16 @@
+namespace CodeReviewExamples.Production.BusinessPartners.Services;
+
+public class BusinessPartnerRepository(OnlineBusinessPartnerRegistry businessPartnerRegistry, IBusinessPartnerArchive businessPartnerArchive)
+{
+    public async Task<RegisteredBusinessPartnerDto> GetBusinessPartnerByCodeAsync(int partnerCode)
+    {
+        if (await businessPartnerArchive.TryGetBusinessPartnerByCodeAsync(partnerCode, out var registeredBusinessPartner))
+            return registeredBusinessPartner;
+
+        if (!await businessPartnerRegistry.TryGetBusinessPartnerByCodeAsync(partnerCode, out registeredBusinessPartner))
+            throw new BusinessPartnerNotFoundException(partnerCode);
+        
+        await businessPartnerArchive.SaveBusinessPartnerToArchiveAsync(registeredBusinessPartner);
+        return registeredBusinessPartner;
+    }
+}

--- a/UnitTest_CodeReviews_SDLC/CodeReviewExamples/Production/BusinessPartners/Services/DbBusinessPartnerArchive.cs
+++ b/UnitTest_CodeReviews_SDLC/CodeReviewExamples/Production/BusinessPartners/Services/DbBusinessPartnerArchive.cs
@@ -1,0 +1,29 @@
+namespace CodeReviewExamples.Production.BusinessPartners.Services;
+
+public class DbBusinessPartnerArchive : IBusinessPartnerArchive
+{
+    public Task<bool> TryGetBusinessPartnerByCodeAsync(int partnerCode, out RegisteredBusinessPartnerDto businessPartnerDto)
+    {
+        //sample implementation
+        businessPartnerDto = null;
+        return Task.FromResult(false);
+    }
+
+    public Task SaveBusinessPartnerToArchiveAsync(RegisteredBusinessPartnerDto registeredBusinessPartner)
+    {
+        //sample implementation
+        return Task.CompletedTask;
+    }
+    
+    public Task RemoveBusinessPartnerFromArchiveAsync(int partnerCode)
+    {
+        //sample implementation
+        return Task.CompletedTask;
+    }
+
+    public Task Clear()
+    {
+        //sample implementation
+        return Task.CompletedTask;
+    }
+}

--- a/UnitTest_CodeReviews_SDLC/CodeReviewExamples/Production/BusinessPartners/Services/IBusinessPartnerArchive.cs
+++ b/UnitTest_CodeReviews_SDLC/CodeReviewExamples/Production/BusinessPartners/Services/IBusinessPartnerArchive.cs
@@ -1,0 +1,9 @@
+namespace CodeReviewExamples.Production.BusinessPartners.Services;
+
+public interface IBusinessPartnerArchive
+{
+    Task<bool> TryGetBusinessPartnerByCodeAsync(int partnerCode, out RegisteredBusinessPartnerDto businessPartnerDto);
+    Task SaveBusinessPartnerToArchiveAsync(RegisteredBusinessPartnerDto registeredBusinessPartner);
+    Task RemoveBusinessPartnerFromArchiveAsync(int partnerCode);
+    Task Clear();
+}

--- a/UnitTest_CodeReviews_SDLC/CodeReviewExamples/Production/BusinessPartners/Services/OnlineBusinessPartnerRegistry.cs
+++ b/UnitTest_CodeReviews_SDLC/CodeReviewExamples/Production/BusinessPartners/Services/OnlineBusinessPartnerRegistry.cs
@@ -1,0 +1,23 @@
+namespace CodeReviewExamples.Production.BusinessPartners.Services;
+
+/// <summary>
+///  Online business partner registry connected to the external OBP service.
+/// </summary>
+public class OnlineBusinessPartnerRegistry : IBusinessPartnerRegistry
+{
+    //sample implementation...
+    private readonly Dictionary<int, RegisteredBusinessPartnerDto> _businessPartnerOnlineRegistry =
+        new()
+        {
+            { 1234, new RegisteredBusinessPartnerDto { PartnerCode = 1234, Origin = RegistryOrigin.Online } }
+        };
+    
+    public virtual Task<bool> TryGetBusinessPartnerByCodeAsync(int partnerCode, out RegisteredBusinessPartnerDto registeredBusinessPartner)
+    {
+        if(!_businessPartnerOnlineRegistry.TryGetValue(partnerCode, out registeredBusinessPartner))
+            return Task.FromResult(false);
+        
+        registeredBusinessPartner = new RegisteredBusinessPartnerDto();
+        return Task.FromResult(true);
+    }
+}

--- a/UnitTest_CodeReviews_SDLC/CodeReviewExamples/Tests/BusinessPartners/BusinessPartnerTests.cs
+++ b/UnitTest_CodeReviews_SDLC/CodeReviewExamples/Tests/BusinessPartners/BusinessPartnerTests.cs
@@ -1,0 +1,56 @@
+using System.Reflection;
+using Xunit;
+using CodeReviewExamples.Production.BusinessPartners;
+using FluentAssertions;
+
+namespace CodeReviewExamples.Tests.BusinessPartners;
+
+public class BusinessPartnerTests
+{
+    private const int DefaultPartnerCode = 1234;
+    private static BusinessPartner _sut = new(DefaultPartnerCode);
+    
+    [Fact]
+    public void NotYetVerified_AsExpected()
+    {
+        _sut = new BusinessPartner(DefaultPartnerCode);
+        var status = typeof(BusinessPartner).GetField("_status", BindingFlags.NonPublic | BindingFlags.Instance);
+        status!.GetValue(_sut).Should().Be(VerificationStatus.Unverified);
+    }
+    
+    [Theory]
+    [InlineData(false, VerificationStatus.Rejected)]
+    [InlineData(true, VerificationStatus.Verified)]
+    public void Verify_AsExpected(bool verify, VerificationStatus expected)
+    {
+        if(verify)
+            _sut.Verify();
+        else
+            _sut.Reject();
+        
+        var status = typeof(BusinessPartner).GetField("_status", BindingFlags.NonPublic | BindingFlags.Instance);
+        status!.GetValue(_sut).Should().Be(expected);
+    }
+
+    [Fact]
+    public void IsEligibleForLeaseContracts_ReturnsTrue()
+    {
+        var status = typeof(BusinessPartner).GetField("_status", BindingFlags.NonPublic | BindingFlags.Instance);
+        status!.SetValue(_sut, VerificationStatus.Verified);
+        
+        _sut.IsEligibleForLeaseContracts().Should().BeTrue();
+    }
+    
+    [Fact]
+    public void IsEligibleForLeaseContracts_ReturnsFalse()
+    {
+        var random = new Random();
+        var notEligibleStatuses = Enum.GetValues<VerificationStatus>().Where(x => x != VerificationStatus.Verified).ToList();
+        var notEligibleStatus = notEligibleStatuses[random.Next(notEligibleStatuses.Count)];
+        
+        var status = typeof(BusinessPartner).GetField("_status", BindingFlags.NonPublic | BindingFlags.Instance);
+        status!.SetValue(_sut, notEligibleStatus);
+        
+        _sut.IsEligibleForLeaseContracts().Should().BeFalse();
+    }
+}

--- a/UnitTest_CodeReviews_SDLC/CodeReviewExamples/Tests/BusinessPartners/Commands/RemoveBusinessPartnerFromArchiveCommandTests.cs
+++ b/UnitTest_CodeReviews_SDLC/CodeReviewExamples/Tests/BusinessPartners/Commands/RemoveBusinessPartnerFromArchiveCommandTests.cs
@@ -1,0 +1,22 @@
+using CodeReviewExamples.Production.BusinessPartners.Commands;
+using CodeReviewExamples.Production.BusinessPartners.Services;
+using Moq;
+using Xunit;
+
+namespace CodeReviewExamples.Tests.BusinessPartners.Commands;
+
+public class RemoveBusinessPartnerFromArchiveCommandTests
+{
+    [Fact]
+    public async Task ExecuteRemoval_PartnerIsRemoved_NoMailIsSentInTestContext()
+    {
+        var mailServiceMock = new Mock<IMailService>();
+        var archiveMock = new Mock<IBusinessPartnerArchive>();
+        const int partnerCode = 1234;
+        var sut = new RemoveBusinessPartnerFromArchiveCommand(true, mailServiceMock.Object, archiveMock.Object);
+
+        await sut.Execute(partnerCode);
+        archiveMock.Verify(x => x.RemoveBusinessPartnerFromArchiveAsync(partnerCode), Times.Once);
+        mailServiceMock.VerifyNoOtherCalls();
+    }
+}

--- a/UnitTest_CodeReviews_SDLC/CodeReviewExamples/Tests/BusinessPartners/Services/BusinessPartnerRepositoryTests.cs
+++ b/UnitTest_CodeReviews_SDLC/CodeReviewExamples/Tests/BusinessPartners/Services/BusinessPartnerRepositoryTests.cs
@@ -1,0 +1,93 @@
+using CodeReviewExamples.Production.BusinessPartners;
+using CodeReviewExamples.Production.BusinessPartners.Services;
+using FluentAssertions;
+using Moq;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace CodeReviewExamples.Tests.BusinessPartners.Services;
+
+public class BusinessPartnerRepositoryTests(ITestOutputHelper testOutputHelper)
+{
+    private readonly DbBusinessPartnerArchive _dbBusinessPartnerArchive = new();
+    
+    [Fact]
+    public async Task GetBusinessPartner_ThrowsException()
+    {
+        const int unknownCode = 0000;
+        var sut = new BusinessPartnerRepository(new OnlineBusinessPartnerRegistry(), _dbBusinessPartnerArchive);
+        
+        var action = async () => await sut.GetBusinessPartnerByCodeAsync(unknownCode);
+        await action.Should().ThrowAsync<BusinessPartnerNotFoundException>();
+    }
+
+    [Fact]
+    public async Task GetBusinessPartnerOnline_ReturnsPartner()
+    {
+        try
+        {
+            const int expectedKnownCode = 1234;
+            await _dbBusinessPartnerArchive.Clear();
+            var sut = new BusinessPartnerRepository(new OnlineBusinessPartnerRegistry(), _dbBusinessPartnerArchive);
+            
+            var result = await sut.GetBusinessPartnerByCodeAsync(expectedKnownCode);
+            AssertRegisteredBusinessPartner(result, expectedKnownCode);
+        }
+        catch (Exception)
+        {
+            testOutputHelper.WriteLine("Error while getting partner from registry.");
+        }
+    }
+    
+    [Fact]
+    public async Task GetBusinessPartnerFromArchive_NoOnlineCallsAreMade_ReturnsPartner()
+    {
+        try
+        {
+            const int expectedKnownCode = 1234;
+            await _dbBusinessPartnerArchive.Clear();
+            var onlineRegistryMock = new Mock<OnlineBusinessPartnerRegistry>();
+            
+            var sut = new BusinessPartnerRepository(new OnlineBusinessPartnerRegistry(), _dbBusinessPartnerArchive);
+            
+            var result = await sut.GetBusinessPartnerByCodeAsync(expectedKnownCode);
+            AssertRegisteredBusinessPartner(result, expectedKnownCode);
+            onlineRegistryMock.Verify(x => x.TryGetBusinessPartnerByCodeAsync(It.IsAny<int>(), out It.Ref<RegisteredBusinessPartnerDto>.IsAny), Times.Never);
+        }
+        catch (Exception)
+        {
+            testOutputHelper.WriteLine("Error while getting partner from registry.");
+        }
+    }
+    
+    [Fact]
+    public async Task GetBusinessPartnerOnline_SavedToArchive()
+    {
+        try
+        {
+            const int expectedKnownCode = 1234;
+            var archiveMock = new Mock<IBusinessPartnerArchive>(MockBehavior.Strict);
+            archiveMock.Setup(x => x.TryGetBusinessPartnerByCodeAsync(expectedKnownCode, out It.Ref<RegisteredBusinessPartnerDto>.IsAny))
+                .ReturnsAsync(false);
+            var sut = new BusinessPartnerRepository(new OnlineBusinessPartnerRegistry(), archiveMock.Object);
+            
+            var result = await sut.GetBusinessPartnerByCodeAsync(expectedKnownCode);
+            
+            AssertRegisteredBusinessPartner(result, expectedKnownCode);
+            archiveMock.Verify(x => x.TryGetBusinessPartnerByCodeAsync(expectedKnownCode, out It.Ref<RegisteredBusinessPartnerDto>.IsAny), Times.Once);
+            archiveMock.Verify(x => x.SaveBusinessPartnerToArchiveAsync(It.Is<RegisteredBusinessPartnerDto>(p => p.PartnerCode == expectedKnownCode)), Times.Once);
+            archiveMock.VerifyNoOtherCalls();
+        }
+        catch (Exception)
+        {
+            testOutputHelper.WriteLine("Error while getting partner from registry.");
+        }
+    }
+
+    private static void AssertRegisteredBusinessPartner(RegisteredBusinessPartnerDto businessPartnerDto, int expectedPartnerCode)
+    {
+        businessPartnerDto.Should().NotBeNull();
+        businessPartnerDto.Should().BeOfType<RegisteredBusinessPartnerDto>();
+        businessPartnerDto.PartnerCode.Should().Be(expectedPartnerCode);
+    }
+}


### PR DESCRIPTION
Added functionality to the business partner for:

- Checking if the partner is eligible for a lease contract
- Verifying the partner and therefore making them eligible for a lease contract
- Rejecting the partner therefore making them non-eligible for a lease contract

- Added a business partner repository for getting business partner from our internal archive or the online registry as well as saving partners to our archive

- Added unit tests